### PR TITLE
chore: update eslint rule no floating promises

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,7 @@ module.exports = {
 	},
 	plugins: ['@typescript-eslint', 'eslint-plugin-import', 'import', 'no-only-tests', 'no-loops', 'jest', 'sort-keys-fix'],
 	rules: {
+		'@typescript-eslint/no-floating-promises': ['error'],
 		// ESLINT
 		// 'no-restricted-imports': [
 		// 	'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "mit",
 			"dependencies": {
 				"date-fns": "3.6.0",
-				"date-fns-tz": "3.0.0",
+				"date-fns-tz": "3.0.1",
 				"joi": "17.12.3",
 				"lodash.clonedeep": "4.5.0",
 				"rxjs": "7.8.1"
@@ -22,9 +22,9 @@
 				"@babel/plugin-transform-modules-commonjs": "7.24.1",
 				"@babel/preset-env": "7.24.4",
 				"@babel/preset-typescript": "7.24.1",
-				"@commitlint/cli": "19.2.1",
+				"@commitlint/cli": "19.2.2",
 				"@commitlint/config-conventional": "19.1.0",
-				"@commitlint/prompt": "19.2.0",
+				"@commitlint/prompt": "19.2.2",
 				"@jest/globals": "29.7.0",
 				"@semantic-release/changelog": "6.0.3",
 				"@semantic-release/commit-analyzer": "12.0.0",
@@ -55,7 +55,7 @@
 				"markdown-toc": "1.2.0",
 				"prettier": "3.2.5",
 				"rimraf": "5.0.5",
-				"semantic-release": "23.0.7",
+				"semantic-release": "23.0.8",
 				"source-map-support": "0.5.21",
 				"ts-cleaner": "1.0.5",
 				"ts-jest": "29.1.2",
@@ -64,7 +64,7 @@
 				"tsc-watch": "6.2.0",
 				"typedoc": "0.25.13",
 				"typedoc-plugin-markdown": "3.17.1",
-				"typescript": "5.4.4"
+				"typescript": "5.4.5"
 			},
 			"engines": {
 				"node": ">=14",
@@ -2089,13 +2089,13 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.2.1.tgz",
-			"integrity": "sha512-cbkYUJsLqRomccNxvoJTyv5yn0bSy05BBizVyIcLACkRbVUqYorC351Diw/XFSWC/GtpwiwT2eOvQgFZa374bg==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.2.2.tgz",
+			"integrity": "sha512-P8cbOHfg2PQRzfICLSrzUVOCVMqjEZ8Hlth6mtJ4yOEjT47Q5PbIGymgX3rLVylNw+3IAT2Djn9IJ2wHbXFzBg==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/format": "^19.0.3",
-				"@commitlint/lint": "^19.1.0",
+				"@commitlint/lint": "^19.2.2",
 				"@commitlint/load": "^19.2.0",
 				"@commitlint/read": "^19.2.1",
 				"@commitlint/types": "^19.0.3",
@@ -2175,9 +2175,9 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.0.3.tgz",
-			"integrity": "sha512-MqDrxJaRSVSzCbPsV6iOKG/Lt52Y+PVwFVexqImmYYFhe51iVJjK2hRhOG2jUAGiUHk4jpdFr0cZPzcBkSzXDQ==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.2.2.tgz",
+			"integrity": "sha512-eNX54oXMVxncORywF4ZPFtJoBm3Tvp111tg1xf4zWXGfhBPKpfKG6R+G3G4v5CPlRROXpAOpQ3HMhA9n1Tck1g==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/types": "^19.0.3",
@@ -2188,12 +2188,12 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "19.1.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.1.0.tgz",
-			"integrity": "sha512-ESjaBmL/9cxm+eePyEr6SFlBUIYlYpI80n+Ltm7IA3MAcrmiP05UMhJdAD66sO8jvo8O4xdGn/1Mt2G5VzfZKw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.2.2.tgz",
+			"integrity": "sha512-xrzMmz4JqwGyKQKTpFzlN0dx0TAiT7Ran1fqEBgEmEj+PU98crOFtysJgY+QdeSagx6EDRigQIXJVnfrI0ratA==",
 			"dev": true,
 			"dependencies": {
-				"@commitlint/is-ignored": "^19.0.3",
+				"@commitlint/is-ignored": "^19.2.2",
 				"@commitlint/parse": "^19.0.3",
 				"@commitlint/rules": "^19.0.3",
 				"@commitlint/types": "^19.0.3"
@@ -2247,9 +2247,9 @@
 			}
 		},
 		"node_modules/@commitlint/prompt": {
-			"version": "19.2.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/prompt/-/prompt-19.2.0.tgz",
-			"integrity": "sha512-bhPftma1IVQP5Y8St0ZssDMi1WJFju6Oz1lKZiQauEbCcHzQjRk3OHygGvNt8EXvvDTETV1jncPOjErgYSQTbQ==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/prompt/-/prompt-19.2.2.tgz",
+			"integrity": "sha512-ib+5XYws/g4VkP+4IkfH+kTJRbiInPMaq9vjPzfgQvBR3o7KWEQBk4P6ZsZK7VdGANcNXTKo667FNsfyQLPZgg==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/ensure": "^19.0.3",
@@ -7140,9 +7140,9 @@
 			}
 		},
 		"node_modules/date-fns-tz": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.0.0.tgz",
-			"integrity": "sha512-YgRowJwvCAAjN1A5F2l1ZjnYKThX7YDq399qo+ThXFpeOqinN1u8SUqfM5IdRQSpai18Iy3EBMb6/CXTSnDstg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.0.1.tgz",
+			"integrity": "sha512-LGKFMKEllm9tCirgYhha3rqfw5nstTULXnKKCk2qO/qju1rfxpUI9IXzmpOd5w727TtrfenAVafql0B/vs6aQQ==",
 			"dependencies": {
 				"lodash.clonedeep": "^4.5.0"
 			},
@@ -17166,6 +17166,35 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
+		"node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-package-up/node_modules/type-fest": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+			"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/read-pkg": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
@@ -17731,9 +17760,9 @@
 			"dev": true
 		},
 		"node_modules/semantic-release": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.7.tgz",
-			"integrity": "sha512-PFxXQE57zrYiCbWKkdsVUF08s0SifEw3WhDhrN47ZEUWQiLl21FI9Dg/H8g7i/lPx0IkF6u7PjJbgxPceXKBeg==",
+			"version": "23.0.8",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.8.tgz",
+			"integrity": "sha512-yZkuWcTTfh5h/DrR4Q4QvJSARJdb6wjwn/sN0qKMYEkvwaVFek8YWfrgtL8oWaRdl0fLte0Y1wWMzLbwoaII1g==",
 			"dev": true,
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^12.0.0",
@@ -17759,7 +17788,7 @@
 				"micromatch": "^4.0.2",
 				"p-each-series": "^3.0.0",
 				"p-reduce": "^3.0.0",
-				"read-pkg-up": "^11.0.0",
+				"read-package-up": "^11.0.0",
 				"resolve-from": "^5.0.0",
 				"semver": "^7.3.2",
 				"semver-diff": "^4.0.0",
@@ -19313,9 +19342,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 	},
 	"dependencies": {
 		"date-fns": "3.6.0",
-		"date-fns-tz": "3.0.0",
+		"date-fns-tz": "3.0.1",
 		"joi": "17.12.3",
 		"lodash.clonedeep": "4.5.0",
 		"rxjs": "7.8.1"
@@ -140,9 +140,9 @@
 		"@babel/plugin-transform-modules-commonjs": "7.24.1",
 		"@babel/preset-env": "7.24.4",
 		"@babel/preset-typescript": "7.24.1",
-		"@commitlint/cli": "19.2.1",
+		"@commitlint/cli": "19.2.2",
 		"@commitlint/config-conventional": "19.1.0",
-		"@commitlint/prompt": "19.2.0",
+		"@commitlint/prompt": "19.2.2",
 		"@jest/globals": "29.7.0",
 		"@semantic-release/changelog": "6.0.3",
 		"@semantic-release/commit-analyzer": "12.0.0",
@@ -173,7 +173,7 @@
 		"markdown-toc": "1.2.0",
 		"prettier": "3.2.5",
 		"rimraf": "5.0.5",
-		"semantic-release": "23.0.7",
+		"semantic-release": "23.0.8",
 		"source-map-support": "0.5.21",
 		"ts-cleaner": "1.0.5",
 		"ts-jest": "29.1.2",
@@ -182,7 +182,7 @@
 		"tsc-watch": "6.2.0",
 		"typedoc": "0.25.13",
 		"typedoc-plugin-markdown": "3.17.1",
-		"typescript": "5.4.4"
+		"typescript": "5.4.5"
 	},
 	"engines": {
 		"node": ">=14",


### PR DESCRIPTION
* fix: bump date-fns-tz from 3.0.0 to 3.0.1

Bumps [date-fns-tz](https://github.com/marnusw/date-fns-tz) from 3.0.0 to 3.0.1.
- [Release notes](https://github.com/marnusw/date-fns-tz/releases)
- [Changelog](https://github.com/marnusw/date-fns-tz/blob/master/CHANGELOG.md)
- [Commits](marnusw/date-fns-tz@v3.0.0...v3.0.1)

---
updated-dependencies:
- dependency-name: date-fns-tz
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump @commitlint/prompt from 19.2.0 to 19.2.2

Bumps [@commitlint/prompt](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/prompt) from 19.2.0 to 19.2.2.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/prompt/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.2.2/@commitlint/prompt)

---
updated-dependencies:
- dependency-name: "@commitlint/prompt"
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump @commitlint/cli from 19.2.1 to 19.2.2

Bumps [@commitlint/cli](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/cli) from 19.2.1 to 19.2.2.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.2.2/@commitlint/cli)

---
updated-dependencies:
- dependency-name: "@commitlint/cli"
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump typescript from 5.4.4 to 5.4.5

Bumps [typescript](https://github.com/Microsoft/TypeScript) from 5.4.4 to 5.4.5.
- [Release notes](https://github.com/Microsoft/TypeScript/releases)
- [Changelog](https://github.com/microsoft/TypeScript/blob/main/azure-pipelines.release.yml)
- [Commits](microsoft/TypeScript@v5.4.4...v5.4.5)

---
updated-dependencies:
- dependency-name: typescript
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump semantic-release from 23.0.7 to 23.0.8

Bumps [semantic-release](https://github.com/semantic-release/semantic-release) from 23.0.7 to 23.0.8.
- [Release notes](https://github.com/semantic-release/semantic-release/releases)
- [Commits](semantic-release/semantic-release@v23.0.7...v23.0.8)

---
updated-dependencies:
- dependency-name: semantic-release
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>